### PR TITLE
Remove oracle JDK from build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,3 @@ before_install:
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up bundle install
-jdk:
-  - oraclejdk8


### PR DESCRIPTION
The dependency in the build for the oracleJDK seems unnecessary and tests pass without it. And Mysql is used in stage/production.